### PR TITLE
update English doc example for Vue / change setip to read setup

### DIFF
--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/introduce/start/zustand-vue.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/introduce/start/zustand-vue.md
@@ -57,7 +57,7 @@ Store binds components are different in `vue3` vs `vue2`。
 <template>
   <div>store.bears: {{ bears }}</div>
 </template>
-<script setip>
+<script setup>
 import useBearStore from "./store";
 const bears = useBearStore((state) => state.bears)
 </script>


### PR DESCRIPTION
little wording typo in En version of the docs.

`<script setip>` should be `<script setup>` for Vue Composition API